### PR TITLE
toggle-touchpad.sh: Make it more general, works on any device now

### DIFF
--- a/toggle-touchpad.sh
+++ b/toggle-touchpad.sh
@@ -1,12 +1,11 @@
-#! /bin/bash
+#!/bin/sh
+# Toggle touchpad status
+# Using libinput and xinput
 
-# toggle touchpad status
+# Use xinput list and do a search for touchpads. Then get the first one and get its name.
+device="$(xinput list | grep -P '(?<= )[\w\s:]*(?i)touchpad(?-i).*?(?=\s*id)' -o | head -n1)"
 
-device="SynPS/2 Synaptics TouchPad"
-enabled=$(xinput --list-props "$device" | grep "Device Enabled" | awk '{print $NF}')
-
-if [[ "$enabled" == "1" ]]; then
-    xinput --disable "$device"
-else
-    xinput --enable "$device"
-fi
+# If it was activated disable it and if it wasn't disable it
+[[ "$(xinput list-props "$device" | grep -P ".*Device Enabled.*\K.(?=$)" -o)" == "1" ]] &&
+    xinput disable "$device" ||
+    xinput enable "$device"


### PR DESCRIPTION
Using grep -P to get the device no matter what is it as far as it is called a touchpad.
Not depending on Awk anymore.

Idk why would anybody care but I'm proud that it uses one less variable xD