### PR TITLE
toggle-touchpad.sh: Support for inputs

### DIFF
--- a/toggle-touchpad.sh
+++ b/toggle-touchpad.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 # Toggle touchpad status
 # Using libinput and xinput
+# 0 input disables in and anything else enables it
+
+toggleto(){ # If input is 0 disable it, otherwise enable it
+    [ "$1" = "0" ] && xinput disable "$device" || xinput enable "$device" ;}
 
 # Use xinput list and do a search for touchpads. Then get the first one and get its name.
 device="$(xinput list | grep -P '(?<= )[\w\s:]*(?i)touchpad(?-i).*?(?=\s*id)' -o | head -n1)"
-
-# If it was activated disable it and if it wasn't disable it
-[[ "$(xinput list-props "$device" | grep -P ".*Device Enabled.*\K.(?=$)" -o)" == "1" ]] &&
-    xinput disable "$device" ||
-    xinput enable "$device"
+# If there is an input switch to that, otherwise just toggle
+[ -n "$1" ] && toggleto "$1" || toggleto "$([ "$(xinput list-props "$device" | grep -P ".*Device Enabled.*\K.(?=$)" -o)" = "1" ] && echo 0 || echo 1)"


### PR DESCRIPTION
In scenarios where the script needs to be bound to keys and there is `XF86TouchpadOff` or `XF86TouchpadOn` instead of `XF86TouchpadToggle` the previous version is basically useless.
Therefore the need for params is there.

This is the binding examples for my `.sxhkd` with this version:
```
XF86TouchpadToggle
	touchpadtoggle
XF86Touchpad{Off,On}
	touchpadtoggle {0,1}
```