### PR TITLE
Added size printing to rmshit.py

### DIFF
--- a/rmshit.py
+++ b/rmshit.py
@@ -106,7 +106,7 @@ def format_size(size_in_bytes):
     unit_index = min(int((size_in_bytes.bit_length() - 1) // 10) , len(units) - 1)
     size /= (1024 ** unit_index)
 
-    return f"{size:.2f} {units[unit_index]}"
+    return f"{size:.4g} {units[unit_index]}"
     
 def rmshit():
     shittyfiles = read_config()

--- a/rmshit.py
+++ b/rmshit.py
@@ -126,6 +126,7 @@ def rmshit():
                 os.remove(f)
             else:
                 shutil.rmtree(f)
+        print("All cleaned")
     else:
         print("No file removed")
 

--- a/rmshit.py
+++ b/rmshit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#! /usr/bin/env python3
 
 import os
 import shutil

--- a/rmshit.py
+++ b/rmshit.py
@@ -101,7 +101,7 @@ def format_size(size_in_bytes):
     if size_in_bytes <= 0:
         return "0 bytes"
 
-    units = ['bytes', 'KB', 'MB', 'GB']
+    units = ['bytes', 'KiB', 'MiB', 'GiB']
     size = float(size_in_bytes)
     unit_index = min(int((size_in_bytes.bit_length() - 1) // 10) , len(units) - 1)
     size /= (1024 ** unit_index)

--- a/rmshit.py
+++ b/rmshit.py
@@ -1,11 +1,10 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 import os
 import shutil
 from pathlib import Path
 
 import yaml
-
 
 DEFAULT_CONFIG = """
 - ~/.adobe              # Flash crap
@@ -61,6 +60,18 @@ DEFAULT_CONFIG = """
 - ~/.local/share/Trash/    # VSCode puts deleted files here
 """
 
+def get_size(path):
+    """Returns the size of a file or directory in bytes."""
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    elif os.path.isdir(path):
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                total_size += os.path.getsize(fp)
+        return total_size
+    return 0
 
 def read_config():
     """
@@ -76,7 +87,6 @@ def read_config():
 
     with open(config_path, "r") as f:
         return yaml.safe_load(f)
-
 
 def yesno(question, default="n"):
     """
@@ -94,7 +104,6 @@ def yesno(question, default="n"):
         return True
     return False
 
-
 def rmshit():
     shittyfiles = read_config()
 
@@ -104,7 +113,8 @@ def rmshit():
         absf = os.path.expanduser(f)
         if os.path.exists(absf):
             found.append(absf)
-            print("    %s" % f)
+            size = get_size(absf)
+            print("    %s (%d bytes)" % (f, size))
 
     if len(found) == 0:
         print("No shitty files found :)")
@@ -116,10 +126,8 @@ def rmshit():
                 os.remove(f)
             else:
                 shutil.rmtree(f)
-        print("All cleaned")
     else:
         print("No file removed")
-
 
 if __name__ == "__main__":
     rmshit()

--- a/rmshit.py
+++ b/rmshit.py
@@ -96,17 +96,31 @@ def yesno(question, default="n"):
         return True
     return False
 
+def format_size(size_in_bytes):
+    """Format file size in bytes to a human-readable string."""
+    if size_in_bytes <= 0:
+        return "0 bytes"
+
+    units = ['bytes', 'KB', 'MB', 'GB']
+    size = float(size_in_bytes)
+    unit_index = min(int((size_in_bytes.bit_length() - 1) // 10) , len(units) - 1)
+    size /= (1024 ** unit_index)
+
+    return f"{size:.2f} {units[unit_index]}"
+    
 def rmshit():
     shittyfiles = read_config()
 
     print("Found shittyfiles:")
     found = []
+    total_size = 0
     for f in shittyfiles:
         absf = os.path.expanduser(f)
         if os.path.exists(absf):
             found.append(absf)
             size = get_size(absf)
-            print(f"    {f} ({size} bytes)")
+            total_size += size
+            print(f"    {f} ({format_size(size)})")
 
     if len(found) == 0:
         print("No shitty files found :)")
@@ -118,7 +132,7 @@ def rmshit():
                 os.remove(f)
             else:
                 shutil.rmtree(f)
-        print("All cleaned")
+        print(f"All cleaned, {format_size(total_size)} freed.")
     else:
         print("No file removed")
 

--- a/rmshit.py
+++ b/rmshit.py
@@ -60,18 +60,8 @@ DEFAULT_CONFIG = """
 - ~/.local/share/Trash/    # VSCode puts deleted files here
 """
 
-def get_size(path):
-    """Returns the size of a file or directory in bytes."""
-    if os.path.isfile(path):
-        return os.path.getsize(path)
-    elif os.path.isdir(path):
-        total_size = 0
-        for dirpath, dirnames, filenames in os.walk(path):
-            for f in filenames:
-                fp = os.path.join(dirpath, f)
-                total_size += os.path.getsize(fp)
-        return total_size
-    return 0
+def get_size(folder):
+    return sum(p.stat().st_size for p in Path(folder).rglob('*'))
 
 def read_config():
     """
@@ -93,7 +83,7 @@ def yesno(question, default="n"):
     Asks the user for YES or NO, always case insensitive.
     Returns True for YES and False for NO.
     """
-    prompt = "%s (y/[n]) " % question
+    prompt = f"{question} (y/[n])"
 
     ans = input(prompt).strip().lower()
 

--- a/rmshit.py
+++ b/rmshit.py
@@ -83,7 +83,7 @@ def yesno(question, default="n"):
     Asks the user for YES or NO, always case insensitive.
     Returns True for YES and False for NO.
     """
-    prompt = f"{question} (y/[n])"
+    prompt = f"{question} (y/[n]) "
 
     ans = input(prompt).strip().lower()
 

--- a/rmshit.py
+++ b/rmshit.py
@@ -60,8 +60,10 @@ DEFAULT_CONFIG = """
 - ~/.local/share/Trash/    # VSCode puts deleted files here
 """
 
-def get_size(folder):
-    return sum(p.stat().st_size for p in Path(folder).rglob('*'))
+def get_size(path):
+    if Path(path).is_dir():
+        return sum(p.stat().st_size for p in Path(path).rglob("*"))
+    return Path(path).stat().st_size
 
 def read_config():
     """

--- a/rmshit.py
+++ b/rmshit.py
@@ -114,7 +114,7 @@ def rmshit():
         if os.path.exists(absf):
             found.append(absf)
             size = get_size(absf)
-            print("    %s (%d bytes)" % (f, size))
+            print(f"    {f} ({size} bytes)")
 
     if len(found) == 0:
         print("No shitty files found :)")


### PR DESCRIPTION
Simply added the feature of printing the size of the found files for `rmshit.py` script.
Now works just like that:
```
[~/.vnc] $ /bin/python /home/vadim/Fromgit/systemtools/Scripts/rmshit.py
Found shittyfiles:
    ~/.local/share/recently-used.xbel (731 bytes)
    ~/.viminfo (1447 bytes)
    ~/.vnc/ (12061 bytes)
Remove all? (y/[n]) y
All cleaned
```